### PR TITLE
Feat(Basic Auth): The basic Auth been configed from the mobile-services.json file.

### DIFF
--- a/FrontPage/AppDelegate.swift
+++ b/FrontPage/AppDelegate.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Apollo
+import AppAuth
 
 let config = Config()
 let syncUrl = config.getConfiguration("sync-app")
@@ -11,9 +12,20 @@ let apollo = ApolloClient(url: URL(string: syncUrl.url)!)
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
+  var currentAuthorizationFlow: OIDExternalUserAgentSession?
   
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     apollo.cacheKeyForObject = { $0["id"] }
     return true
   }
+
+  func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey : Any] = [:]) -> Bool {
+      if let authorizationFlow = self.currentAuthorizationFlow, authorizationFlow.resumeExternalUserAgentFlow(with: url) {
+          self.currentAuthorizationFlow = nil
+          return true
+      }
+
+      return false
+  }
+  
 }

--- a/FrontPage/AuthViewController.swift
+++ b/FrontPage/AuthViewController.swift
@@ -1,0 +1,214 @@
+import Foundation
+import UIKit
+import AppAuth
+
+
+typealias PostRegistrationCallback = (_ configuration: OIDServiceConfiguration?, _ registrationResponse: OIDRegistrationResponse?) -> Void
+
+let authConfig = config.getConfiguration("keycloak").config ?? ["error": JSONValue.bool(false)]
+let server = authConfig["auth-server-url"]?.getString() ?? "error";
+let realms = authConfig["realm"]?.getString() ?? "error"
+
+let kIssuer: String = server + "/realms/" + realms + "/";
+let kClientID: String? = authConfig["resource"]?.getString() ?? "error";
+let kRedirectURI: String = "com.myapp://restore";
+let AuthStateKey: String = "authState";
+
+class AuthViewController: UIViewController {
+  
+  private var authState: OIDAuthState?
+  
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    self.loadState()
+  }
+  
+  override func viewDidAppear(_ animated: Bool) {
+    super.viewDidAppear(animated)
+    if (authState?.isAuthorized ?? false){
+      self.setAuthState(nil)
+      self.changeView()
+    } else {
+      self.authWithAutoCodeExchange()
+    }
+  }
+}
+
+extension AuthViewController {
+  func authWithAutoCodeExchange() {
+    
+    guard let issuer = URL(string: kIssuer) else {
+      self.logMessage("Error creating URL for : \(kIssuer)")
+      return
+    }
+    
+    self.logMessage("Fetching configuration for issuer: \(issuer)")
+    
+    // discovers endpoints
+    OIDAuthorizationService.discoverConfiguration(forIssuer: issuer) { configuration, error in
+      
+      guard let config = configuration else {
+        self.logMessage("Error retrieving discovery document: \(error?.localizedDescription ?? "DEFAULT_ERROR")")
+        self.setAuthState(nil)
+        return
+      }
+      
+      self.logMessage("Got configuration: \(config)")
+      
+      if let clientId = kClientID {
+        self.doAuthWithAutoCodeExchange(configuration: config, clientID: clientId, clientSecret: nil)
+      } else {
+        self.doClientRegistration(configuration: config) { configuration, response in
+          
+          guard let configuration = configuration, let clientID = response?.clientID else {
+            self.logMessage("Error retrieving configuration OR clientID")
+            return
+          }
+          
+          self.doAuthWithAutoCodeExchange(configuration: configuration,
+                                          clientID: clientID,
+                                          clientSecret: response?.clientSecret)
+        }
+      }
+    }
+    
+  }
+}
+
+//MARK: AppAuth Methods
+extension AuthViewController {
+  
+  func doClientRegistration(configuration: OIDServiceConfiguration, callback: @escaping PostRegistrationCallback) {
+    
+    guard let redirectURI = URL(string: kRedirectURI) else {
+      self.logMessage("Error creating URL for : \(kRedirectURI)")
+      return
+    }
+    
+    let request: OIDRegistrationRequest = OIDRegistrationRequest(configuration: configuration,
+                                                                 redirectURIs: [redirectURI],
+                                                                 responseTypes: nil,
+                                                                 grantTypes: nil,
+                                                                 subjectType: nil,
+                                                                 tokenEndpointAuthMethod: "client_secret_post",
+                                                                 additionalParameters: nil)
+    
+    // performs registration request
+    self.logMessage("Initiating registration request")
+    
+    OIDAuthorizationService.perform(request) { response, error in
+      
+      if let regResponse = response {
+        self.setAuthState(OIDAuthState(registrationResponse: regResponse))
+        self.logMessage("Got registration response: \(regResponse)")
+        callback(configuration, regResponse)
+      } else {
+        self.logMessage("Registration error: \(error?.localizedDescription ?? "DEFAULT_ERROR")")
+        self.setAuthState(nil)
+      }
+    }
+  }
+  
+  func doAuthWithAutoCodeExchange(configuration: OIDServiceConfiguration, clientID: String, clientSecret: String?) {
+    
+    guard let redirectURI = URL(string: kRedirectURI) else {
+      self.logMessage("Error creating URL for : \(kRedirectURI)")
+      return
+    }
+    
+    guard let appDelegate = UIApplication.shared.delegate as? AppDelegate else {
+      self.logMessage("Error accessing AppDelegate")
+      return
+    }
+    
+    // builds authentication request
+    let request = OIDAuthorizationRequest(configuration: configuration,
+                                          clientId: clientID,
+                                          clientSecret: clientSecret,
+                                          scopes: [OIDScopeOpenID, OIDScopeProfile],
+                                          redirectURL: redirectURI,
+                                          responseType: OIDResponseTypeCode,
+                                          additionalParameters: nil)
+    
+    // performs authentication request
+    logMessage("Initiating authorization request with scope: \(request.scope ?? "DEFAULT_SCOPE")")
+    
+    appDelegate.currentAuthorizationFlow = OIDAuthState.authState(byPresenting: request, presenting: self) { authState, error in
+      
+      if let authState = authState {
+        self.setAuthState(authState)
+        self.logMessage("Got authorization tokens. Access token: \(authState.lastTokenResponse?.accessToken ?? "DEFAULT_TOKEN")")
+        AppDelegate.auth = true
+        self.changeView()
+        
+      } else {
+        self.logMessage("Authorization error: \(error?.localizedDescription ?? "DEFAULT_ERROR")")
+        self.setAuthState(nil)
+      }
+    }
+  }
+  
+}
+
+//MARK: OIDAuthState Delegate
+extension AuthViewController: OIDAuthStateChangeDelegate, OIDAuthStateErrorDelegate {
+  
+  func didChange(_ state: OIDAuthState) {
+    self.stateChanged()
+  }
+  
+  func authState(_ state: OIDAuthState, didEncounterAuthorizationError error: Error) {
+    self.logMessage("Received authorization error: \(error)")
+  }
+}
+
+//MARK: Helper Methods
+extension AuthViewController {
+  
+  func saveState() {
+    
+    var data: Data? = nil
+    
+    if let authState = self.authState {
+      data = NSKeyedArchiver.archivedData(withRootObject: authState)
+    }
+    
+    UserDefaults.standard.set(data, forKey: AuthStateKey)
+    UserDefaults.standard.synchronize()
+  }
+  
+  func loadState() {
+    guard let data = UserDefaults.standard.object(forKey: AuthStateKey) as? Data else {
+      return
+    }
+    
+    if let authState = NSKeyedUnarchiver.unarchiveObject(with: data) as? OIDAuthState {
+      self.setAuthState(authState)
+    }
+  }
+  
+  func setAuthState(_ authState: OIDAuthState?) {
+    if (self.authState == authState) {
+      return;
+    }
+    self.authState = authState;
+    self.authState?.stateChangeDelegate = self;
+    self.stateChanged()
+  }
+  
+  func stateChanged() {
+    self.saveState()
+  }
+  
+  func logMessage(_ message: String) {
+    print(message)
+  }
+  
+  func changeView() {
+    let storyBoard: UIStoryboard = UIStoryboard(name: "Main", bundle: nil)
+    let newViewController = storyBoard.instantiateViewController(withIdentifier: "PostView") as! PostListViewController
+    self.present(newViewController, animated: true, completion: nil)
+    
+  }
+  
+}

--- a/FrontPage/Base.lproj/Main.storyboard
+++ b/FrontPage/Base.lproj/Main.storyboard
@@ -1,44 +1,48 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11201" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Uda-Cx-To4">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14868" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="ieq-Tx-BQi">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11161"/>
-        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14824"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
         <!--Posts-->
         <scene sceneID="Xxi-hM-Y9P">
             <objects>
-                <tableViewController id="vrK-5c-2N3" customClass="PostListViewController" customModule="FrontPage" customModuleProvider="target" sceneMemberID="viewController">
+                <tableViewController storyboardIdentifier="PostView" useStoryboardIdentifierAsRestorationIdentifier="YES" id="vrK-5c-2N3" customClass="PostListViewController" customModule="FrontPage" sceneMemberID="viewController">
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="plain" separatorStyle="default" allowsSelection="NO" rowHeight="80" sectionHeaderHeight="28" sectionFooterHeight="28" id="It9-xP-cez">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="Cell" id="R7q-H8-hJ4" customClass="PostTableViewCell" customModule="FrontPage" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="92" width="375" height="80"/>
+                                <rect key="frame" x="0.0" y="28" width="414" height="80"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" tableViewCell="R7q-H8-hJ4" id="n1f-fF-ddI">
-                                    <frame key="frameInset" width="375" height="79.5"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="414" height="80"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                     <subviews>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" text="Byline" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="tIF-Zy-a4e">
+                                            <rect key="frame" x="20" y="35" width="41.5" height="18"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" text="Votes" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hPE-vT-f5c">
+                                            <rect key="frame" x="69.5" y="38" width="32" height="14.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleCaption1"/>
                                             <color key="textColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" preservesSuperviewLayoutMargins="YES" text="Title" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="lDJ-zd-S4j">
+                                            <rect key="frame" x="20" y="11" width="35.5" height="20.5"/>
                                             <fontDescription key="fontDescription" style="UICTFontTextStyleHeadline"/>
                                             <nil key="textColor"/>
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <button opaque="NO" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="LF6-qT-HmW">
+                                            <rect key="frame" x="344" y="25" width="50" height="30"/>
                                             <state key="normal" title="Upvote"/>
                                             <connections>
                                                 <action selector="upvote" destination="R7q-H8-hJ4" eventType="touchUpInside" id="6rk-1B-orl"/>
@@ -73,7 +77,7 @@
                 </tableViewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="cau-fh-Fka" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="664.79999999999995" y="-1287.7061469265368"/>
+            <point key="canvasLocation" x="1828" y="-1288"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="StO-WY-5Yd">
@@ -81,17 +85,37 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Uda-Cx-To4" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" id="8Dj-8i-az8">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="44" width="414" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
                     <nil name="viewControllers"/>
                     <connections>
-                        <segue destination="vrK-5c-2N3" kind="relationship" relationship="rootViewController" id="sG6-nP-V9Y"/>
+                        <segue destination="vrK-5c-2N3" kind="relationship" relationship="rootViewController" id="yAQ-Ws-a3t"/>
+                        <segue destination="ieq-Tx-BQi" kind="showDetail" id="Alz-Ln-9Dc"/>
                     </connections>
                 </navigationController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="C5i-Ub-2t0" userLabel="First Responder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="-274.39999999999998" y="-1287.7061469265368"/>
+        </scene>
+        <!--Auth View Controller-->
+        <scene sceneID="sYP-OZ-VGx">
+            <objects>
+                <viewController storyboardIdentifier="AuthView" modalPresentationStyle="fullScreen" useStoryboardIdentifierAsRestorationIdentifier="YES" id="ieq-Tx-BQi" customClass="AuthViewController" customModule="FrontPage" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="mmO-eP-PJu"/>
+                        <viewControllerLayoutGuide type="bottom" id="hGd-yo-G0T"/>
+                    </layoutGuides>
+                    <view key="view" hidden="YES" clipsSubviews="YES" contentMode="scaleToFill" id="VbO-eE-2FO">
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="AWk-mV-dX6"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="MhN-vF-74O" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="595.6521739130435" y="-1763.1696428571429"/>
         </scene>
     </scenes>
 </document>

--- a/FrontPage/Info.plist
+++ b/FrontPage/Info.plist
@@ -16,6 +16,17 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleTypeRole</key>
+      <string>Editor</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>com.myapp</string>
+      </array>
+    </dict>
+  </array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/Podfile
+++ b/Podfile
@@ -3,4 +3,5 @@ use_frameworks!
 
 target 'FrontPage' do
   pod 'Apollo', '~> 0.13.0'
+  pod 'AppAuth', '~> 1.2.0'
 end


### PR DESCRIPTION
Added basic auth.

- On first launch of the app the user is asked to log into a keyclock server. Once logged in gets redirected to the list view.
- Exit the app.
- Launch the app again. The user is logged directly in using the token that is saved to the device. 
- For demo propose, the token is removed from the device. This set the app to a logged out state if the app is launched for a 3rd time. 